### PR TITLE
gnupg2: add gnupg modern (2.1.19)

### DIFF
--- a/Formula/dscanner.rb
+++ b/Formula/dscanner.rb
@@ -2,8 +2,8 @@ class Dscanner < Formula
   desc "Analyses e.g. the style and syntax of D code."
   homepage "https://github.com/Hackerpilot/Dscanner"
   url "https://github.com/Hackerpilot/Dscanner.git",
-    :tag => "v0.3.0",
-    :revision => "ab08f0b28b2851063e273f5f8073b575a4d17083"
+    :tag => "v0.4.0",
+    :revision => "87e42ae1941aeda81cc8e6c4343ab3c8d77036cd"
 
   head "https://github.com/Hackerpilot/Dscanner.git"
 
@@ -12,13 +12,6 @@ class Dscanner < Formula
     sha256 "e4109d118bfc3ea842bf3d2aa9588dec4e5be8350557f644727b752ec261cd32" => :el_capitan
     sha256 "5f8b2e4fb9df04ba43eaba0c1f7fe53c3cee1bf71c4f23f0fcd7871c7269ba4a" => :yosemite
     sha256 "93916657176868ebab187de76075da38ef1f62e7fcf126670c297d1413c172af" => :mavericks
-  end
-
-  devel do
-    url "https://github.com/Hackerpilot/Dscanner.git",
-      :tag => "v0.4.0-beta.3",
-      :revision => "bf3b942b9a102616c4c67611301738883845c906"
-    version "0.4.0-beta.3"
   end
 
   depends_on "dmd" => :build

--- a/Formula/dscanner.rb
+++ b/Formula/dscanner.rb
@@ -8,10 +8,9 @@ class Dscanner < Formula
   head "https://github.com/Hackerpilot/Dscanner.git"
 
   bottle do
-    sha256 "21462544cf3d662d79ad62fac0d27a6d6346404a4c7a58f1d0e3df86962a17b4" => :sierra
-    sha256 "e4109d118bfc3ea842bf3d2aa9588dec4e5be8350557f644727b752ec261cd32" => :el_capitan
-    sha256 "5f8b2e4fb9df04ba43eaba0c1f7fe53c3cee1bf71c4f23f0fcd7871c7269ba4a" => :yosemite
-    sha256 "93916657176868ebab187de76075da38ef1f62e7fcf126670c297d1413c172af" => :mavericks
+    sha256 "cee064b929cb506b88e7bed826e94ec8b8ffbf04e19767f6c10a8a816007978b" => :sierra
+    sha256 "01f7abb878de76d8d6617c285edbe035e11c5ea35964b9d79edab28c96429cc2" => :el_capitan
+    sha256 "c7ab84fde1c0551f7a61b2e833cb62c085923680a614a6a1ce5101143753eff8" => :yosemite
   end
 
   depends_on "dmd" => :build

--- a/Formula/eigen.rb
+++ b/Formula/eigen.rb
@@ -1,8 +1,8 @@
 class Eigen < Formula
   desc "C++ template library for linear algebra"
   homepage "https://eigen.tuxfamily.org/"
-  url "https://bitbucket.org/eigen/eigen/get/3.3.2.tar.bz2"
-  sha256 "3e1fa6e8c45635938193f84fee6c35a87fac26ee7c39c68c230e5080c4a8fe98"
+  url "https://bitbucket.org/eigen/eigen/get/3.3.3.tar.bz2"
+  sha256 "a4143fc45e4454b4b98fcea3516b3a79b8cdb3bc7fadf996d088c6a0d805fea1"
   head "https://bitbucket.org/eigen/eigen", :using => :hg
 
   bottle do

--- a/Formula/eigen.rb
+++ b/Formula/eigen.rb
@@ -7,9 +7,9 @@ class Eigen < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "141c35bade90aea1f3fcca7652dd7a28850467986aef26aa887370f5a0bf28fa" => :sierra
-    sha256 "26ef36ab67b11af368ac89fb1e6209136d3f9992bb825deec7399527fe75fa39" => :el_capitan
-    sha256 "141c35bade90aea1f3fcca7652dd7a28850467986aef26aa887370f5a0bf28fa" => :yosemite
+    sha256 "4dfbf894bb931eb44ebcadd1065d162d46916a9d93420a81596d049ccfb54820" => :sierra
+    sha256 "4dfbf894bb931eb44ebcadd1065d162d46916a9d93420a81596d049ccfb54820" => :el_capitan
+    sha256 "4dfbf894bb931eb44ebcadd1065d162d46916a9d93420a81596d049ccfb54820" => :yosemite
   end
 
   depends_on "cmake" => :build

--- a/Formula/heroku.rb
+++ b/Formula/heroku.rb
@@ -1,9 +1,9 @@
 class Heroku < Formula
   desc "Everything you need to get started with Heroku"
   homepage "https://cli.heroku.com"
-  url "https://cli-assets.heroku.com/branches/stable/5.6.11-3b6a56e/heroku-v5.6.11-3b6a56e-darwin-amd64.tar.xz"
-  version "5.6.11-3b6a56e"
-  sha256 "a69969374ca559f0f1e76905ef6ae856280d2cce859e7cd68357c201ef96a99d"
+  url "https://cli-assets.heroku.com/branches/stable/5.6.28-2643c0a/heroku-v5.6.28-2643c0a-darwin-amd64.tar.xz"
+  version "5.6.28-2643c0a"
+  sha256 "7d0320800410821349a0f44be1ca49619388ef934e3ae2334b7c6b1f5028da95"
 
   bottle :unneeded
 

--- a/Formula/kotlin.rb
+++ b/Formula/kotlin.rb
@@ -1,8 +1,8 @@
 class Kotlin < Formula
   desc "Statically typed programming language for the JVM"
   homepage "https://kotlinlang.org/"
-  url "https://github.com/JetBrains/kotlin/releases/download/v1.0.6/kotlin-compiler-1.0.6.zip"
-  sha256 "42a20b72d1e90f9efa9d13aab97559f478cc32b7c2e6da8569cdc3741a8e14b6"
+  url "https://github.com/JetBrains/kotlin/releases/download/v1.1/kotlin-compiler-1.1.zip"
+  sha256 "aa44db28bf3ccdae8842b6b92bec5991eb430a80e580aafbc6a044678a2f359d"
 
   bottle :unneeded
 

--- a/Formula/sane-backends.rb
+++ b/Formula/sane-backends.rb
@@ -25,6 +25,8 @@ class SaneBackends < Formula
     sha256 "37f8e076bdddbdc868076456c308d21fbbef40ab647297f69bf5ca4b88a07688" => :mavericks
   end
 
+  option :universal
+
   depends_on "jpeg"
   depends_on "libtiff"
   depends_on "libusb-compat"
@@ -32,6 +34,7 @@ class SaneBackends < Formula
   depends_on "net-snmp"
 
   def install
+    ENV.universal_binary if build.universal?
     ENV.deparallelize # Makefile does not seem to be parallel-safe
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/swagger-codegen.rb
+++ b/Formula/swagger-codegen.rb
@@ -1,8 +1,8 @@
 class SwaggerCodegen < Formula
   desc "Generation of client and server from Swagger definition"
-  homepage "http://swagger.io/swagger-codegen/"
-  url "https://github.com/swagger-api/swagger-codegen/archive/v2.2.1.tar.gz"
-  sha256 "bdf6d5828cdcdeb43f377d58f13a73f8c297fb90c3bad900f0e0a266ebf8d778"
+  homepage "https://swagger.io/swagger-codegen/"
+  url "https://github.com/swagger-api/swagger-codegen/archive/v2.2.2.tar.gz"
+  sha256 "59f2fcd130836a61d8093cf711ccb34feb157762c36d7cb452e93a899ce1ed26"
   head "https://github.com/swagger-api/swagger-codegen.git"
 
   bottle do

--- a/Formula/swagger-codegen.rb
+++ b/Formula/swagger-codegen.rb
@@ -7,10 +7,9 @@ class SwaggerCodegen < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "514301a5707ccafbab4435d840d7ad99817a38bf3e2392cd33c68d8de09653bd" => :sierra
-    sha256 "8d4c728aacf862c15a22bb254365fd9d557acaa144f0e9eccd72b7e09c207174" => :el_capitan
-    sha256 "43283ffa36d261cf9723866ac0f825b92e0a37212de27645819ebe14117fdcfa" => :yosemite
-    sha256 "01614863b7c91a94b27ecccda0bf6617244c53d43cf641a4148bdead33031a33" => :mavericks
+    sha256 "4b9948e4fa6a29dafb419a6ead0fa2072d3a0e209564b94639bedb531da1a681" => :sierra
+    sha256 "ba9912568441c56fd72a38e73648e8119643bdc4115f438ba399bc60cca156a2" => :el_capitan
+    sha256 "c482f92fa2688b5f15ecad071e8945c7fb10e24b4fc2aa134c4a351133aa6dc9" => :yosemite
   end
 
   depends_on :java => "1.7+"

--- a/Formula/webp.rb
+++ b/Formula/webp.rb
@@ -18,12 +18,15 @@ class Webp < Formula
     depends_on "libtool" => :build
   end
 
+  option :universal
+
   depends_on "libpng"
   depends_on "jpeg" => :recommended
   depends_on "libtiff" => :optional
   depends_on "giflib" => :optional
 
   def install
+    ENV.universal_binary if build.universal?
     system "./autogen.sh" if build.head?
 
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/xz.rb
+++ b/Formula/xz.rb
@@ -14,7 +14,10 @@ class Xz < Formula
     sha256 "82eef73a78db1c46ed8482c357f6ad1797a62f4c9124410b362efe885082892c" => :yosemite
   end
 
+  option :universal
+
   def install
+    ENV.universal_binary if build.universal?
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
This is a port from homebrew/versions with the following changes:

* Updated version from 2.1.18 to 2.1.19
* Removed necessary patches for 2.1.18
* Use `test` option (instead of ignoring it)
* Use `keg_only :versioned_formula` and remove conflicts_with
* Removed SHA256 for bottles (cannot build them locally)

Tested and found to be working on MacOS Sierra 10.12.3.